### PR TITLE
Create Full Occupancy endpoint

### DIFF
--- a/web/modules/custom/hous_z_api/src/Plugin/rest/resource/FullOccupancyResource.php
+++ b/web/modules/custom/hous_z_api/src/Plugin/rest/resource/FullOccupancyResource.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\hous_z_api\Plugin\rest\resource;
+
+use Drupal\rest\Plugin\ResourceBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @RestResource(
+ *   id = "full_occupancy_resource",
+ *   label = @Translation("Full Occupancy"),
+ *   uri_paths = {
+ *     "canonical" = "/api/full-occupancy"
+ *   }
+ * )
+ */
+class FullOccupancyResource extends ResourceBase implements \Drupal\Core\Plugin\ContainerFactoryPluginInterface {
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, array $serializer_formats, LoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('hous_z_api')
+    );
+  }
+
+  public function get() {
+    $startDt = new DrupalDateTime('today');
+    $endDt = (clone $startDt)->modify('+12 months');
+    $interval = new \DateInterval('P1D');
+    $period = new \DatePeriod($startDt->getPhpDateTime(), $interval, $endDt->getPhpDateTime());
+
+    $storage_unit = \Drupal::entityTypeManager()->getStorage('bat_unit');
+    $storage_event = \Drupal::entityTypeManager()->getStorage('bat_event');
+    $unit_ids = $storage_unit->getQuery()->accessCheck(FALSE)->execute();
+    $units = $storage_unit->loadMultiple($unit_ids);
+    $unique_days = [];
+
+    foreach ($period as $day) {
+      $dateStr = $day->format('Y-m-d');
+      $dateStart = $dateStr . 'T00:00:00';
+      $dateEnd = $dateStr . 'T23:59:59';
+      $isFullyOccupied = TRUE;
+
+      foreach ($units as $unit) {
+        $beds = $unit->get('field_beds')->referencedEntities();
+        foreach ($beds as $bed) {
+          $bed_type = $bed->get('field_bed_type')->value;
+          $bed_quantity = (int)$bed->get('field_bed_quantity')->value;
+
+          $events_query = $storage_event->getQuery()
+            ->accessCheck(FALSE)
+            ->condition('type', 'availability_daily')
+            ->condition('event_bat_unit_reference', $unit->id())
+            ->condition('field_bed_type', $bed_type)
+            ->condition('event_dates.value', $dateEnd, '<=')
+            ->condition('event_dates.end_value', $dateStart, '>=');
+          $event_ids = $events_query->execute();
+
+          if (count($event_ids) < $bed_quantity) {
+            $isFullyOccupied = FALSE;
+            break 2;
+          }
+        }
+      }
+
+      if ($isFullyOccupied) {
+        $year = $day->format('Y');
+        $month = (int)$day->format('n');
+        $d = (int)$day->format('j');
+        $unique_days["$year-$month-$d"] = [
+          'year' => $year,
+          'month' => $month,
+          'month_name' => $day->format('F'),
+          'day' => $d,
+        ];
+      }
+    }
+
+    $payload = ['calendar' => ['years' => []]];
+    foreach ($unique_days as $item) {
+      $Y = $item['year'];
+      $M = $item['month'];
+      $d = $item['day'];
+
+      if (!isset($payload['calendar']['years'][$Y])) {
+        $payload['calendar']['years'][$Y] = ['months' => []];
+      }
+      if (!isset($payload['calendar']['years'][$Y]['months'][$M])) {
+        $payload['calendar']['years'][$Y]['months'][$M] = [
+          'name' => $item['month_name'],
+          'number' => $M,
+          'days' => [],
+        ];
+      }
+      $already_exists = false;
+      foreach ($payload['calendar']['years'][$Y]['months'][$M]['days'] as $dayItem) {
+        if ($dayItem['day'] === $d) {
+          $already_exists = true;
+          break;
+        }
+      }
+      if (!$already_exists) {
+        $payload['calendar']['years'][$Y]['months'][$M]['days'][] = [
+          'day' => $d,
+          'available' => false,
+        ];
+      }
+    }
+
+    return new JsonResponse($payload);
+  }
+}


### PR DESCRIPTION
Pull Request: Add's Full Occupancy Endpoint

Summary:
This PR Add FullOccupancyResource for accurate reporting of fully booked days.

⸻

How to test:
	1.	Clear caches: drush cr
	2.	Hit /api/full-occupancy
	3.	Confirm response lists only days when all rooms/beds are booked, including day ranges

⸻

Response Example:

```{
    "calendar": {
        "years": {
            "2025": {
                "months": {
                    "6": {
                        "name": "June",
                        "number": 6,
                        "days": [
                            {
                                "day": 25,
                                "available": false
                            },
                            {
                                "day": 26,
                                "available": false
                            },
                            {
                                "day": 27,
                                "available": false
                            },
                            {
                                "day": 28,
                                "available": false
                            },
                            {
                                "day": 29,
                                "available": false
                            },
                            {
                                "day": 30,
                                "available": false
                            }
                        ]
                    },
                    "7": {
                        "name": "July",
                        "number": 7,
                        "days": [
                            {
                                "day": 1,
                                "available": false
                            },
                            {
                                "day": 2,
                                "available": false
                            },
                            {
                                "day": 3,
                                "available": false
                            }
                        ]
                    }
                }
            },
            "2026": {
                "months": {
                    "1": {
                        "name": "January",
                        "number": 1,
                        "days": [
                            {
                                "day": 13,
                                "available": false
                            },
                            {
                                "day": 14,
                                "available": false
                            },
                            {
                                "day": 15,
                                "available": false
                            }
                        ]
                    }
                }
            }
        }
    }
}